### PR TITLE
Add a FAQ entry for liborc installation

### DIFF
--- a/gr-azure-software-radio/README.md
+++ b/gr-azure-software-radio/README.md
@@ -94,7 +94,7 @@ The Key Vault block allows users to pull down keys and secrets from an [Azure Ke
 
 It is expected that the user will setup and store secrets in an Azure Key Vault prior to pulling down keys using this block. To create a Key Vault, see [Create Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/secrets/quick-create-cli).
 
-See the [Key Vault Example](../examples/README.md#key-vault-example).
+See the [Key Vault Example](./examples/README.md#key-vault-example).
 
 
 ## Blob Blocks

--- a/gr-azure-software-radio/docs/FAQ.md
+++ b/gr-azure-software-radio/docs/FAQ.md
@@ -15,6 +15,21 @@
 
   If the version conflicts are due to the Azure CLI installation using pip, refer to the [Azure CLI Installation](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) for the recommended installation options.  
 
+## Why is my build complaining about liborc and failing?
+  If you get a failure related to liborc when trying to compile the OOT module that looks like this:
+  ```
+  make[2]: *** No rule to make target '/usr/lib/x86_64-linux-gnu/liborc-0.4.so', needed by 'lib/libgnuradio-azure_software_radio.so.v1.0-compat-xxx-xunknown'.  Stop.
+  make[1]: *** [CMakeFiles/Makefile2:251: lib/CMakeFiles/gnuradio-azure_software_radio.dir/all] Error 2
+  make: *** [Makefile:141: all] Error 2
+  ```
+
+  You'll need to install the liborc package. On Ubuntu 20.04, you can install the missing package by running:
+  ```
+  sudo apt install liborc-0.4-dev
+  ```
+
+  You should now be able to compile gr-azure-software-radio.
+
 ## Failures importing azure_software_radio in the flowgraph  
   By default Azure software radio will be installed in the ``` /usr/local/ ``` directory. Use the ``` CMAKE_INSTALL_PREFIX ``` to install elsewhere.  
 


### PR DESCRIPTION
This updates the FAQ to include what to do if the build fails due to liborc not being installed. 

This also updates the gr-azure-software-radio README to fix a broken link to the Key Vault example. 