### PR TITLE
Exit Eventhub integration tests gracefully

### DIFF
--- a/gr-azure-software-radio/python/integration_eventhub_sink.py
+++ b/gr-azure-software-radio/python/integration_eventhub_sink.py
@@ -134,12 +134,13 @@ class IntegrationEventhubSink(gr_unittest.TestCase):
             'in' in pmt.to_python(
                 sink_block.message_ports_in()), True)
 
-        self.tb.run()
+        self.tb.start()
         with self.eventhub_consumer:
             self.eventhub_consumer.receive(
                 on_event=self.on_event,
                 starting_position=test_start_time)
         self.assertEqual(NUM_MSGS, self.num_rx_msgs)
+        self.tb.stop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Refactor Eventhub Source test and call stop to properly close the EventHubConsumerClient