### PR TITLE
CLI and Other Reqs

### DIFF
--- a/gr-azure-software-radio/README.md
+++ b/gr-azure-software-radio/README.md
@@ -37,11 +37,11 @@ You will need to install and configure the following before installing the Azure
 GnuRadio 3.9.0 or greater
 python 3.8 or greater
 ```
-NOTE: If you have installed the Azure CLI with the default apt package on Ubuntu 20, the install may fail or the module may crash at runtime. See [Ubuntu 20 CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt)
+NOTE: If you have installed the Azure CLI with the default apt package on Ubuntu 20, the install may fail or the module may crash at runtime.(suggest minimum version or installation method) See [Ubuntu 20 CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt)
 ### Installing Azure software radio OOT
 
 ```
-pip install -r python/requirements.txt
+pip install -r python/requirements.txt  <------contents of this doc are unknown.
 
 mkdir build
 cd build


### PR DESCRIPTION
would it be appropriate to suggest a minimum CLI version? For example: "Install the latest version of the CLI commands (2.0 or later). For information about installing the CLI commands, see"


pip install -r python/requirements.txt 
contents of the file above are unknown