### PR TITLE
set subscription before creating resource group

### DIFF
--- a/gr-azure-software-radio/README.md
+++ b/gr-azure-software-radio/README.md
@@ -112,7 +112,12 @@ First, you must log in to azure, you can use [az login](https://github.com/Micro
 ```azurecli-interactive
 az login
 ```
-First, we must create a resource group:
+Set the subscription for which you want to create the VM
+```azurecli-interactive
+az account set --subscription "<subscription ID>
+```
+
+Create a resource group:
 ```azurecli-interactive
 az group create --name azsr-sdk-test-rg --location westus
 ```


### PR DESCRIPTION
azure tutorials offer a reminder to set the right subscription from the start. See this example from express route (https://docs.microsoft.com/en-us/azure/expressroute/howto-circuit-cli)



Check the subscriptions for the account.
az account list

Select the subscription for which you want to create an ExpressRoute circuit.
az account set --subscription "<subscription ID>"