### PR TITLE
Add repeat option to Blob Source

### DIFF
--- a/gr-azure-software-radio/grc/azure_software_radio_blob_source.block.yml
+++ b/gr-azure-software-radio/grc/azure_software_radio_blob_source.block.yml
@@ -19,7 +19,8 @@ templates:
                                         ${container_name},
                                         ${blob_name},
                                         ${queue_size},
-                                        ${retry_total})
+                                        ${retry_total},
+                                        ${repeat})
 
 parameters:
 - id: type
@@ -67,6 +68,12 @@ parameters:
   label: Retry Total
   dtype: int
   default: 10
+- id: repeat
+  label: Repeat
+  dtype: enum
+  default: 'False'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
 
 outputs:
 - label: out

--- a/gr-azure-software-radio/python/blob_source.py
+++ b/gr-azure-software-radio/python/blob_source.py
@@ -207,10 +207,9 @@ class BlobSource(gr.sync_block):
                 self.num_buf_bytes_read = 0
                 self.buf = np.zeros((0, ), dtype=np.byte)
                 self.blob_complete = False
-                return 0
-            else:
-                shutdown_blob_service_client(self.blob_service_client)
-                return -1
+                return 0 # will cause work function to start over
+            shutdown_blob_service_client(self.blob_service_client)
+            return -1
 
         # do we have anything to produce?
         nitems_produced = min(int(num_remaining_bytes/self.item_size), noutput_items)

--- a/gr-azure-software-radio/python/blob_source.py
+++ b/gr-azure-software-radio/python/blob_source.py
@@ -50,7 +50,7 @@ class BlobSource(gr.sync_block):
     # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method
     def __init__(self, np_dtype: np.dtype, vlen: int = 1, authentication_method: str = "default",
                  connection_str: str = None, url: str = None, container_name: str = None, blob_name: str = None,
-                 queue_size: int = 4, retry_total: int = 10):
+                 queue_size: int = 4, retry_total: int = 10, repeat: bool = False):
         """ Initialize the blob_source block
 
         Args:
@@ -65,6 +65,8 @@ class BlobSource(gr.sync_block):
                 buffer up before blocking. Larger numbers require more memory overhead
             retry_total (int, optional): Total number of Azure API retries to allow before throwing
                 an exception
+            repeat (bool): To repeat the file or not.  Currently does not cache locally so repeating
+                will cause additional traffic.
         """
         # work-around the following deprecation in numpy:
         # FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated
@@ -81,6 +83,7 @@ class BlobSource(gr.sync_block):
         self.queue = queue.Queue(maxsize=queue_size)
         self.buf = np.zeros((0, ), dtype=np.byte)
         self.num_buf_bytes_read = 0
+        self.repeat = repeat
 
         self.blob_service_client = get_blob_service_client(
             authentication_method=authentication_method,
@@ -183,9 +186,7 @@ class BlobSource(gr.sync_block):
 
         # connect to the blob service the first time we run
         if self.first_run:
-
             self.blob_auth_and_container_info_is_valid()
-
             self.blob_iter = self.setup_blob_iterator()
             self.first_run = False
 
@@ -201,8 +202,15 @@ class BlobSource(gr.sync_block):
 
         # check if we're done
         if self.queue.empty() and num_remaining_bytes == 0 and self.blob_complete:
-            shutdown_blob_service_client(self.blob_service_client)
-            return -1
+            if self.repeat:
+                self.blob_iter = self.setup_blob_iterator()
+                self.num_buf_bytes_read = 0
+                self.buf = np.zeros((0, ), dtype=np.byte)
+                self.blob_complete = False
+                return 0
+            else:
+                shutdown_blob_service_client(self.blob_service_client)
+                return -1
 
         # do we have anything to produce?
         nitems_produced = min(int(num_remaining_bytes/self.item_size), noutput_items)

--- a/gr-azure-software-radio/python/integration_blob_source.py
+++ b/gr-azure-software-radio/python/integration_blob_source.py
@@ -156,6 +156,38 @@ class IntegrationBlobSource(gr_unittest.TestCase):
         self.round_trip_test_helper(dtype=np.complex64,
                                     sink=blocks.vector_sink_c(vlen=vlen),
                                     vlen=vlen)
+    def test_repeat(self):
+        blob_name = 'test-blob.npy'
+        num_samples = 100000
+        repeat_N_times = 3 # we limit the blob source when in repeat mode using a head block
+
+        # set up a vector source with known complex data
+        src_data = np.arange(0, num_samples, 1, dtype=np.float32)
+
+        # connect to the test blob container and upload our test data
+        blob_client = self.blob_service_client.get_blob_client(
+            container=self.test_blob_container_name,
+            blob=blob_name)
+        blob_client.upload_blob(data=src_data.tobytes(), blob_type='BlockBlob')
+
+        op_block = BlobSource(np_dtype=np.float32,
+                              vlen=1,
+                              authentication_method="connection_string",
+                              connection_str=self.blob_connection_string,
+                              container_name=self.test_blob_container_name,
+                              blob_name=blob_name,
+                              queue_size=4,
+                              retry_total=0,
+                              repeat=True) # Note we are repeating this time, the default is False
+
+        vector_sink = blocks.vector_sink_f()
+        head = blocks.head(4, num_samples*repeat_N_times)
+        self.top_block.connect(op_block, head)
+        self.top_block.connect(head, vector_sink)
+        self.top_block.run()
+
+        repeated_src_data = np.tile(src_data, repeat_N_times) # numpy tile will emulate what we're doing here
+        self.assertEqual(repeated_src_data.tolist(), vector_sink.data())
 
 if __name__ == '__main__':
     gr_unittest.run(IntegrationBlobSource)

--- a/gr-azure-software-radio/python/integration_blob_source.py
+++ b/gr-azure-software-radio/python/integration_blob_source.py
@@ -157,6 +157,9 @@ class IntegrationBlobSource(gr_unittest.TestCase):
                                     sink=blocks.vector_sink_c(vlen=vlen),
                                     vlen=vlen)
     def test_repeat(self):
+        """
+        Test the repeat feature of blob source using a head block to limit the output length
+        """
         blob_name = 'test-blob.npy'
         num_samples = 100000
         repeat_N_times = 3 # we limit the blob source when in repeat mode using a head block


### PR DESCRIPTION
It's set to False by default, and when False there should be no changes to the behavior.  When True it essentially just resets itself, I tested it with the FM listening flowgraph and it seemed to repeat the signal just fine.  I added an integration test that tests the repeat functionality.  Existing unit and integration tests still work.