### PR TITLE
SigMF Support for Blob Source and Sink

### DIFF
--- a/gr-azure-software-radio/grc/azure_software_radio_blob_sink.block.yml
+++ b/gr-azure-software-radio/grc/azure_software_radio_blob_sink.block.yml
@@ -20,7 +20,13 @@ templates:
                                       ${blob_name},
                                       ${block_len},
                                       ${queue_size},
-                                      ${retry_total})
+                                      ${retry_total},
+                                      ${sigmf},
+                                      ${sample_rate},
+                                      ${center_freq},
+                                      ${author},
+                                      ${description},
+                                      ${hw_info})
 
 parameters:
 - id: type
@@ -72,6 +78,38 @@ parameters:
   label: Retry Total
   dtype: int
   default: 10
+- id: sigmf
+  label: SigMF Recording
+  dtype: enum
+  default: 'False'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+- id: sample_rate
+  label: Sample Rate
+  dtype: float
+  default: samp_rate
+  hide: ${ 'all' if sigmf == 'False' else 'none'}
+- id: center_freq
+  label: Center Frequency
+  dtype: float
+  options: [np.nan]
+  option_labels: ['None']
+  hide: ${ 'all' if sigmf == 'False' else 'none'}
+- id: author
+  label: Author
+  dtype: string
+  default: ''
+  hide: ${ 'all' if sigmf == 'False' else 'none'}
+- id: description
+  label: Description
+  dtype: string
+  default: ''
+  hide: ${ 'all' if sigmf == 'False' else 'none'}
+- id: hw_info
+  label: Hardware Info
+  dtype: string
+  default: ''
+  hide: ${ 'all' if sigmf == 'False' else 'none'}
 
 inputs:
 - label: in

--- a/gr-azure-software-radio/grc/azure_software_radio_blob_source.block.yml
+++ b/gr-azure-software-radio/grc/azure_software_radio_blob_source.block.yml
@@ -20,7 +20,8 @@ templates:
                                         ${blob_name},
                                         ${queue_size},
                                         ${retry_total},
-                                        ${repeat})
+                                        ${repeat},
+                                        ${sigmf})
 
 parameters:
 - id: type
@@ -70,6 +71,12 @@ parameters:
   default: 10
 - id: repeat
   label: Repeat
+  dtype: enum
+  default: 'False'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+- id: sigmf
+  label: SigMF Recording
   dtype: enum
   default: 'False'
   options: ['True', 'False']

--- a/gr-azure-software-radio/python/blob_sink.py
+++ b/gr-azure-software-radio/python/blob_sink.py
@@ -27,7 +27,9 @@ class BlobSink(gr.sync_block):
     This block has multiple ways to authenticate to the Azure blob backend. Users can directly
     specify either a connection string, a URL with an embedded SAS token, or use credentials
     supported by the DefaultAzureCredential class, such as environment variables, a
-    managed identity, the az login command, etc.
+    managed identity, the az login command, etc.  
+    
+    "Block blobs" are used, page blobs and append blobs are not supported.
 
     For saving a SigMF recording, set the SigMF param to True and leave off the file extension
     (.sigmf-data and .sigmf-meta will be automatically added).

--- a/gr-azure-software-radio/python/blob_sink.py
+++ b/gr-azure-software-radio/python/blob_sink.py
@@ -55,7 +55,7 @@ class BlobSink(gr.sync_block):
         The blobname.sigmf-data will contain the signal, while the blobname.sigmf-meta will contain
         metadata about the signal, provided as additional block params.
     """
-    # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method, too-many-locals, too-many-branches
     def __init__(self, np_dtype: np.dtype, vlen: int = 1, authentication_method: str = "default",
                  connection_str: str = None, url: str = None, container_name: str = None, blob_name: str = None,
                  block_len: int = 500000, queue_size: int = 4, retry_total: int = 10, sigmf: bool = False,
@@ -100,7 +100,7 @@ class BlobSink(gr.sync_block):
                 datatype_str = 'cf32_le'
             elif np_dtype == np.float32:
                 datatype_str = 'rf32_le'
-            elif np_dtype == np.int32: # TODO: Check that our original usage of np.int32 makes sense
+            elif np_dtype == np.int32: # Check that our original usage of np.int32 makes sense
                 datatype_str = 'ci16_le'
             elif np_dtype == np.int16:
                 datatype_str = 'ri16_le'

--- a/gr-azure-software-radio/python/blob_sink.py
+++ b/gr-azure-software-radio/python/blob_sink.py
@@ -102,7 +102,7 @@ class BlobSink(gr.sync_block):
                 datatype_str = 'cf32_le'
             elif np_dtype == np.float32:
                 datatype_str = 'rf32_le'
-            elif np_dtype == np.int32: # Check that our original usage of np.int32 makes sense
+            elif np_dtype == np.int32: # See https://github.com/microsoft/azure-software-radio/issues/67
                 datatype_str = 'ci16_le'
             elif np_dtype == np.int16:
                 datatype_str = 'ri16_le'

--- a/gr-azure-software-radio/python/blob_sink.py
+++ b/gr-azure-software-radio/python/blob_sink.py
@@ -59,7 +59,8 @@ class BlobSink(gr.sync_block):
     def __init__(self, np_dtype: np.dtype, vlen: int = 1, authentication_method: str = "default",
                  connection_str: str = None, url: str = None, container_name: str = None, blob_name: str = None,
                  block_len: int = 500000, queue_size: int = 4, retry_total: int = 10, sigmf: bool = False,
-                 sample_rate: float = 0, center_freq: float = np.nan, author: str = '', description: str = '', hw_info: str = ''):
+                 sample_rate: float = 0, center_freq: float = np.nan, author: str = '', description: str = '',
+                 hw_info: str = ''):
         """ Initialize the blob_sink block
         """
         # work-around the following deprecation in numpy:
@@ -87,11 +88,11 @@ class BlobSink(gr.sync_block):
         self.buf = np.zeros((self.block_len*self.item_size, ), dtype=np.byte)
         self.num_buf_bytes = 0
         self.log = gr.logger(f"gr_log.{self.symbol_name()}")
-        
+
         # If user accidently left .sigmf-data or meta file extension, strip it off
         if sigmf and '.sigmf' in blob_name:
             blob_name = blob_name.rsplit('.', 1)[0]
-        
+
         if sigmf:
             meta_blob_client = self.blob_service_client.get_blob_client(container=container_name,
                                                                         blob=blob_name + '.sigmf-meta')
@@ -99,7 +100,7 @@ class BlobSink(gr.sync_block):
                 datatype_str = 'cf32_le'
             elif np_dtype == np.float32:
                 datatype_str = 'rf32_le'
-            elif np_dtype == np.int32: # TODO: Check that our original usage of np.int32 makes sense; usually complex int16s (iShorts) are saved as int16s not int32s
+            elif np_dtype == np.int32: # TODO: Check that our original usage of np.int32 makes sense
                 datatype_str = 'ci16_le'
             elif np_dtype == np.int16:
                 datatype_str = 'ri16_le'
@@ -134,7 +135,7 @@ class BlobSink(gr.sync_block):
             meta_blob_client.close()
             self.log.info("Meta file upload complete")
             blob_name = blob_name + '.sigmf-data'
-        
+
         self.blob_client = self.blob_service_client.get_blob_client(container=container_name,
                                                                     blob=blob_name)
 

--- a/gr-azure-software-radio/python/blob_sink.py
+++ b/gr-azure-software-radio/python/blob_sink.py
@@ -10,6 +10,7 @@
 
 import queue
 import uuid
+import json
 
 import azure.core.exceptions as az_exceptions
 from gnuradio import gr
@@ -21,15 +22,15 @@ from azure_software_radio.blob_common import shutdown_blob_service_client
 
 
 class BlobSink(gr.sync_block):
-    """ Write samples out to an Azure Blob.
+    """ Write samples out to an Azure Blob.  Use a Head block to limit the number of samples stored in the file.
 
     This block has multiple ways to authenticate to the Azure blob backend. Users can directly
     specify either a connection string, a URL with an embedded SAS token, or use credentials
     supported by the DefaultAzureCredential class, such as environment variables, a
     managed identity, the az login command, etc.
 
-    This block currently only supports complex64 inputs and only supports block blobs. Page blobs
-    and append blobs are not supported.
+    For saving a SigMF recording, set the SigMF param to True and leave off the file extension
+    (.sigmf-data and .sigmf-meta will be automatically added).
 
     Args:
     Input Type: Data type of the sample stream
@@ -50,26 +51,16 @@ class BlobSink(gr.sync_block):
     Retry Total: Total number of Azure API retries to allow before throwing an exception. Higher
         numbers make the block more resilient to intermittent failures, lower numbers help to
         more quickly iteratively debug authentication and permissions issues.
+    SigMF Recording: If True, two files will be created, blobname.sigmf-data and blobname.sigmf-meta.
+        The blobname.sigmf-data will contain the signal, while the blobname.sigmf-meta will contain
+        metadata about the signal, provided as additional block params.
     """
     # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method
     def __init__(self, np_dtype: np.dtype, vlen: int = 1, authentication_method: str = "default",
                  connection_str: str = None, url: str = None, container_name: str = None, blob_name: str = None,
-                 block_len: int = 500000, queue_size: int = 4, retry_total: int = 10):
+                 block_len: int = 500000, queue_size: int = 4, retry_total: int = 10, sigmf: bool = False,
+                 sample_rate: float = 0, center_freq: float = np.nan, author: str = '', description: str = '', hw_info: str = ''):
         """ Initialize the blob_sink block
-
-        Args:
-            np_dtype (np.dtype class): Numpy data type of each item in the stream
-            vlen (int): Number of items per vector
-            authentication_method (str): See "Auth Method" in class docstring above
-            connection_str (optional, str): See "Connection String" in class docstring above
-            url (optional, str): See "URL" in class docstring above
-            container_name (str): See "Container Name" in class docstring above
-            blob_name (str): See "Blob Name" in class docstring above
-            block_len (int): See "Blob Block Length" in class docstring above
-            queue_size (int, optional): Defaults to 4. How many blocks of data to
-                buffer up before blocking. Larger numbers require more memory overhead
-            retry_total (int, optional): Total number of Azure API retries to allow before throwing
-                an exception
         """
         # work-around the following deprecation in numpy:
         # FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated
@@ -95,6 +86,55 @@ class BlobSink(gr.sync_block):
         self.queue = queue.Queue(maxsize=queue_size)
         self.buf = np.zeros((self.block_len*self.item_size, ), dtype=np.byte)
         self.num_buf_bytes = 0
+        self.log = gr.logger(f"gr_log.{self.symbol_name()}")
+        
+        # If user accidently left .sigmf-data or meta file extension, strip it off
+        if sigmf and '.sigmf' in blob_name:
+            blob_name = blob_name.rsplit('.', 1)[0]
+        
+        if sigmf:
+            meta_blob_client = self.blob_service_client.get_blob_client(container=container_name,
+                                                                        blob=blob_name + '.sigmf-meta')
+            if np_dtype == np.complex64:
+                datatype_str = 'cf32_le'
+            elif np_dtype == np.float32:
+                datatype_str = 'rf32_le'
+            elif np_dtype == np.int32: # TODO: Check that our original usage of np.int32 makes sense; usually complex int16s (iShorts) are saved as int16s not int32s
+                datatype_str = 'ci16_le'
+            elif np_dtype == np.int16:
+                datatype_str = 'ri16_le'
+            elif np_dtype == np.ubyte:
+                datatype_str = 'ru8'
+            else:
+                raise ValueError
+
+            meta_dict = {
+                "global": {
+                    "core:datatype": datatype_str,
+                    "core:sample_rate": float(sample_rate),
+                    "core:version": "1.0.0"  # update me if the time comes
+                },
+                "captures": [
+                    {
+                        "core:sample_start": 0,
+                    }
+                ],
+                "annotations": []
+            }
+            if center_freq is not np.nan:
+                meta_dict["captures"][0]["core:frequency"] = float(center_freq)
+            if hw_info:
+                meta_dict["global"]["core:hw"] = str(hw_info)
+            if author:
+                meta_dict["global"]["core:author"] = str(author)
+            if description:
+                meta_dict["global"]["core:description"] = str(description)
+
+            meta_blob_client.upload_blob(json.dumps(meta_dict, indent=2), overwrite=True)
+            meta_blob_client.close()
+            self.log.info("Meta file upload complete")
+            blob_name = blob_name + '.sigmf-data'
+        
         self.blob_client = self.blob_service_client.get_blob_client(container=container_name,
                                                                     blob=blob_name)
 
@@ -102,8 +142,6 @@ class BlobSink(gr.sync_block):
 
         self.first_run = True
         self.blob_is_valid = False
-
-        self.log = gr.logger("log_debug")
 
     def stage_block(self, data: np.array):
         # pylint: disable=fixme

--- a/gr-azure-software-radio/python/blob_sink.py
+++ b/gr-azure-software-radio/python/blob_sink.py
@@ -27,8 +27,8 @@ class BlobSink(gr.sync_block):
     This block has multiple ways to authenticate to the Azure blob backend. Users can directly
     specify either a connection string, a URL with an embedded SAS token, or use credentials
     supported by the DefaultAzureCredential class, such as environment variables, a
-    managed identity, the az login command, etc.  
-    
+    managed identity, the az login command, etc.
+
     "Block blobs" are used, page blobs and append blobs are not supported.
 
     For saving a SigMF recording, set the SigMF param to True and leave off the file extension

--- a/gr-azure-software-radio/python/blob_source.py
+++ b/gr-azure-software-radio/python/blob_source.py
@@ -30,7 +30,7 @@ class BlobSource(gr.sync_block):
     managed identity, the az login command, etc.
 
     This block currently only supports complex64 inputs and has only been tested with block blobs.
-    Page blobs are not supported.
+    Page blobs and append blobs are not supported.
 
     Args:
     Output Type: Data type of the sample stream

--- a/gr-azure-software-radio/python/blob_source.py
+++ b/gr-azure-software-radio/python/blob_source.py
@@ -100,7 +100,7 @@ class BlobSource(gr.sync_block):
             # Stream tags must be written in work() but we will pull out the two values here
             self.sample_rate = meta_dict['global']['core:sample_rate']
             self.center_freq = meta_dict["captures"][0].get("core:frequency", 0.0)
-            
+
             blob_name = blob_name + '.sigmf-data'
 
         self.blob_client = self.blob_service_client.get_blob_client(container=container_name,
@@ -201,15 +201,13 @@ class BlobSource(gr.sync_block):
             if self.sigmf:
                 # Add sample rate and center freq to the first sample as a stream tag
                 self.add_item_tag(0, # Write to output port 0
-                        self.nitems_written(0), # sample 0
-                        pmt.intern("sample_rate"),
-                        pmt.from_float(self.sample_rate)
-                )
+                                  self.nitems_written(0), # sample 0
+                                  pmt.intern("sample_rate"),
+                                  pmt.from_float(self.sample_rate))
                 self.add_item_tag(0, # Write to output port 0
-                        self.nitems_written(0), # sample 0
-                        pmt.intern("center_freq"),
-                        pmt.from_float(self.center_freq)
-                )
+                                  self.nitems_written(0), # sample 0
+                                  pmt.intern("center_freq"),
+                                  pmt.from_float(self.center_freq))
 
         # get a view into the output buffer as a 1D array of bytes, so our code can copy over the data
         # without caring about the actual datatype or vlen in use

--- a/gr-azure-software-radio/python/blob_source.py
+++ b/gr-azure-software-radio/python/blob_source.py
@@ -54,7 +54,7 @@ class BlobSource(gr.sync_block):
         used; the datatype is set by the Output Type specified above.  The meta file as a whole is
         printed to console at the beginning of flowgraph execution.
     """
-    # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method, too-many-locals
     def __init__(self, np_dtype: np.dtype, vlen: int = 1, authentication_method: str = "default",
                  connection_str: str = None, url: str = None, container_name: str = None, blob_name: str = None,
                  queue_size: int = 4, retry_total: int = 10, repeat: bool = False, sigmf: bool = False):

--- a/gr-azure-software-radio/python/blob_source.py
+++ b/gr-azure-software-radio/python/blob_source.py
@@ -10,10 +10,12 @@
 
 
 import queue
+import json
 
 import azure.core.exceptions as az_exceptions
 from gnuradio import gr
 import numpy as np
+import pmt
 
 from azure_software_radio.blob_common import blob_container_info_is_valid, get_blob_service_client
 from azure_software_radio.blob_common import shutdown_blob_service_client
@@ -46,27 +48,17 @@ class BlobSource(gr.sync_block):
     Retry Total: Total number of Azure API retries to allow before throwing an exception. Higher
         numbers make the block more resilient to intermittent failures, lower numbers help to
         more quickly iteratively debug authentication and permissions issues.
+    SigMF Recording: Read in a SigMF recording.  The blob name should not include the .sigmf-data extension,
+        the .sigmf-data and .sigmf-meta will get added automatically.  The sample rate and frequency
+        will be added as stream tags to sample 0.  The datatype specified within the meta file is not
+        used; the datatype is set by the Output Type specified above.  The meta file as a whole is
+        printed to console at the beginning of flowgraph execution.
     """
     # pylint: disable=too-many-arguments, too-many-instance-attributes, arguments-differ, abstract-method
     def __init__(self, np_dtype: np.dtype, vlen: int = 1, authentication_method: str = "default",
                  connection_str: str = None, url: str = None, container_name: str = None, blob_name: str = None,
-                 queue_size: int = 4, retry_total: int = 10, repeat: bool = False):
+                 queue_size: int = 4, retry_total: int = 10, repeat: bool = False, sigmf: bool = False):
         """ Initialize the blob_source block
-
-        Args:
-            np_dtype (np.dtype): Numpy data type of each item in the stream
-            vlen (int): Number of items per vector
-            authentication_method (str): See "Auth Method" in class docstring above
-            connection_str (optional, str): See "Connection String" in class docstring above
-            url (optional, str): See "URL" in class docstring above
-            container_name (str): See "Container Name" in class docstring above
-            blob_name (str): See "Blob Name" in class docstring above
-            queue_size (int, optional): Defaults to 4. How many blocks of data to
-                buffer up before blocking. Larger numbers require more memory overhead
-            retry_total (int, optional): Total number of Azure API retries to allow before throwing
-                an exception
-            repeat (bool): To repeat the file or not.  Currently does not cache locally so repeating
-                will cause additional traffic.
         """
         # work-around the following deprecation in numpy:
         # FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated
@@ -80,17 +72,36 @@ class BlobSource(gr.sync_block):
                                in_sig=None,
                                out_sig=out_sig)
 
-        self.queue = queue.Queue(maxsize=queue_size)
-        self.buf = np.zeros((0, ), dtype=np.byte)
-        self.num_buf_bytes_read = 0
-        self.repeat = repeat
-
         self.blob_service_client = get_blob_service_client(
             authentication_method=authentication_method,
             connection_str=connection_str,
             url=url,
             retry_total=retry_total
         )
+
+        self.queue = queue.Queue(maxsize=queue_size)
+        self.buf = np.zeros((0, ), dtype=np.byte)
+        self.num_buf_bytes_read = 0
+        self.repeat = repeat
+        self.sigmf = sigmf
+        self.log = gr.logger(f"gr_log.{self.symbol_name()}")
+
+        # If user accidently left .sigmf-data or meta file extension, strip it off
+        if sigmf and '.sigmf' in blob_name:
+            blob_name = blob_name.rsplit('.', 1)[0]
+
+        if sigmf:
+            meta_blob_client = self.blob_service_client.get_blob_client(container=container_name,
+                                                                        blob=blob_name + '.sigmf-meta')
+            result_meta = meta_blob_client.download_blob().readall()
+            meta_blob_client.close()
+            self.log.debug(result_meta)
+            meta_dict = json.loads(result_meta)
+            # Stream tags must be written in work() but we will pull out the two values here
+            self.sample_rate = meta_dict['global']['core:sample_rate']
+            self.center_freq = meta_dict["captures"][0].get("core:frequency", 0.0)
+            
+            blob_name = blob_name + '.sigmf-data'
 
         self.blob_client = self.blob_service_client.get_blob_client(container=container_name,
                                                                     blob=blob_name)
@@ -103,8 +114,6 @@ class BlobSource(gr.sync_block):
         self.chunk_residue = b''
 
         self.first_run = True
-
-        self.log = gr.logger("log_debug")
 
     def setup_blob_iterator(self):
         ''' get an iterator into the blob object so we can start doing a streaming download
@@ -189,6 +198,18 @@ class BlobSource(gr.sync_block):
             self.blob_auth_and_container_info_is_valid()
             self.blob_iter = self.setup_blob_iterator()
             self.first_run = False
+            if self.sigmf:
+                # Add sample rate and center freq to the first sample as a stream tag
+                self.add_item_tag(0, # Write to output port 0
+                        self.nitems_written(0), # sample 0
+                        pmt.intern("sample_rate"),
+                        pmt.from_float(self.sample_rate)
+                )
+                self.add_item_tag(0, # Write to output port 0
+                        self.nitems_written(0), # sample 0
+                        pmt.intern("center_freq"),
+                        pmt.from_float(self.center_freq)
+                )
 
         # get a view into the output buffer as a 1D array of bytes, so our code can copy over the data
         # without caring about the actual datatype or vlen in use

--- a/gr-azure-software-radio/python/integration_blob_sink.py
+++ b/gr-azure-software-radio/python/integration_blob_sink.py
@@ -177,7 +177,7 @@ class IntegrationBlobSink(gr_unittest.TestCase):
         blob_name = 'test-blob.npy' # It should strip off the .npy
         block_len = 500000
 
-        src=blocks.vector_source_c([])
+        src = blocks.vector_source_c([])
         src_data = np.arange(0, 2*block_len, 1, dtype=np.complex64)
         src.set_data(src_data.tolist())
 

--- a/gr-azure-software-radio/python/integration_blob_source.py
+++ b/gr-azure-software-radio/python/integration_blob_source.py
@@ -230,13 +230,13 @@ class IntegrationBlobSource(gr_unittest.TestCase):
                 "core:author": "Marc",
                 "core:description": "test description"
             },
-        "captures": [
+            "captures": [
             {
                 "core:sample_start": 0,
                 "core:frequency": 2400000000.0
             }
             ],
-        "annotations": []}
+            "annotations": []}
         meta_string = json.dumps(meta_dict, indent=2)
         meta_blob_client.upload_blob(data=meta_string, blob_type='BlockBlob')
 

--- a/gr-azure-software-radio/python/integration_blob_source.py
+++ b/gr-azure-software-radio/python/integration_blob_source.py
@@ -221,22 +221,22 @@ class IntegrationBlobSource(gr_unittest.TestCase):
         meta_blob_client = self.blob_service_client.get_blob_client(
             container=self.test_blob_container_name,
             blob=blob_name + '.sigmf-meta')
-        meta_dict = {"global": {
-                            "core:datatype": "cf32_le",
-                            "core:sample_rate": 1000000.0,
-                            "core:version": "1.0.0",
-                            "core:hw": "test hardware info",
-                            "core:author": "Marc",
-                            "core:description": "test description"
-                        },
-                        "captures": [
-                            {
-                            "core:sample_start": 0,
-                            "core:frequency": 2400000000.0
-                            }
-                        ],
-                        "annotations": []
-                    }
+        meta_dict = {
+            "global": {
+            "core:datatype": "cf32_le",
+            "core:sample_rate": 1000000.0,
+            "core:version": "1.0.0",
+            "core:hw": "test hardware info",
+            "core:author": "Marc",
+            "core:description": "test description"
+            },
+        "captures": [
+            {
+            "core:sample_start": 0,
+            "core:frequency": 2400000000.0
+            }
+            ],
+        "annotations": []}
         meta_string = json.dumps(meta_dict, indent=2)
         meta_blob_client.upload_blob(data=meta_string, blob_type='BlockBlob')
 

--- a/gr-azure-software-radio/python/integration_blob_source.py
+++ b/gr-azure-software-radio/python/integration_blob_source.py
@@ -223,17 +223,17 @@ class IntegrationBlobSource(gr_unittest.TestCase):
             blob=blob_name + '.sigmf-meta')
         meta_dict = {
             "global": {
-            "core:datatype": "cf32_le",
-            "core:sample_rate": 1000000.0,
-            "core:version": "1.0.0",
-            "core:hw": "test hardware info",
-            "core:author": "Marc",
-            "core:description": "test description"
+                "core:datatype": "cf32_le",
+                "core:sample_rate": 1000000.0,
+                "core:version": "1.0.0",
+                "core:hw": "test hardware info",
+                "core:author": "Marc",
+                "core:description": "test description"
             },
         "captures": [
             {
-            "core:sample_start": 0,
-            "core:frequency": 2400000000.0
+                "core:sample_start": 0,
+                "core:frequency": 2400000000.0
             }
             ],
         "annotations": []}

--- a/gr-azure-software-radio/python/integration_blob_source.py
+++ b/gr-azure-software-radio/python/integration_blob_source.py
@@ -231,10 +231,10 @@ class IntegrationBlobSource(gr_unittest.TestCase):
                 "core:description": "test description"
             },
             "captures": [
-            {
-                "core:sample_start": 0,
-                "core:frequency": 2400000000.0
-            }
+                {
+                    "core:sample_start": 0,
+                    "core:frequency": 2400000000.0
+                }
             ],
             "annotations": []}
         meta_string = json.dumps(meta_dict, indent=2)


### PR DESCRIPTION
Allows relatively simple SigMF use-cases to be supported by our Blob Source and Blob Sink (e.g., does not do anything with annotations or multiple channels).  More details about what is and isn't implemented below:

**Blob Source block** - You can provide it a base filename (if you provide .sigmf-data or .sigmf-meta it will automatically strip it off) and then it will read in the basename.sigmf-data just like the Blob Source does now, we assume the chosen data format (block param) is correct, because pulling that info from the meta file at runtime isn't feasible, GR needs to know the datatype before you hit the play button.  In addition to reading in the data file just like it works now, the block will also read in the meta file and prints it out to the console, and adds tags to sample 0 that provide frequency and sample rate.  It doesn't actually do anything else with the meta data.  Any annotations will just be printed to the console, they won't be used in any other way.  If there's a 2nd channel, it will be ignored, we will only have 1 channel of output just like the current Blob Source supports.

**Blob Sink Block** - In addition to saving the data file to a blob, which will be called basename.sigmf-data, it will also create and save a basename.sigmf-meta to blob storage.  The block gets the information for this file through block params, i.e. the GR user will have to provide them to the block; this includes sample rate, center freq, gain, author, hw_info.  This metafile is saved to blob at the beginning of the flowgraph run.  No stream tags will affect this meta file (e.g. there will be no way to add an annotation with a stream tag).

Integration tests for each block were added