### PR TITLE
DIFI Sink - added include fcntl.h to top

### DIFF
--- a/gr-azure-software-radio/lib/difi_sink_cpp_impl.cc
+++ b/gr-azure-software-radio/lib/difi_sink_cpp_impl.cc
@@ -6,6 +6,7 @@
 #include <gnuradio/io_signature.h>
 #include "difi_sink_cpp_impl.h"
 #include <arpa/inet.h>
+#include <fcntl.h>
 
 namespace gr {
   namespace azure_software_radio {


### PR DESCRIPTION
seems to be needed for certain installs, e.g. using current 3.10 from the PPA I get an error at compile time if I don't have it.